### PR TITLE
update to toml.7.0.0

### DIFF
--- a/dirsift.opam
+++ b/dirsift.opam
@@ -46,7 +46,7 @@ depends: [
   "containers" {>= "3.0"}
   "fileutils"
   "cmdliner"
-  "toml" {>= "6.0.0"}
+  "toml" {>= "7.0.0"}
   "timere"
   "timere-parse"
   "dune-build-info"

--- a/src/dirsift.ml
+++ b/src/dirsift.ml
@@ -26,7 +26,7 @@ let config_of_toml_table (table : Toml.Types.table) : (config, string) result =
     let hot_upper_bound =
       match
         Toml.Types.Table.(
-          find_opt (Key.bare_key_of_string hot_upper_bound_key) table)
+          find_opt (Key.of_string hot_upper_bound_key) table)
       with
       | None -> default_config.hot_upper_bound
       | Some (Toml.Types.TString s) -> (
@@ -44,7 +44,7 @@ let config_of_toml_table (table : Toml.Types.table) : (config, string) result =
     let warm_upper_bound =
       match
         Toml.Types.Table.(
-          find_opt (Key.bare_key_of_string warm_upper_bound_key) table)
+          find_opt (Key.of_string warm_upper_bound_key) table)
       with
       | None -> default_config.warm_upper_bound
       | Some (Toml.Types.TString s) -> (


### PR DESCRIPTION
Hi, I'm about to release toml.7.0.0, in this release, there's no more distinction between the different kind of keys.